### PR TITLE
Add Portuguese OCR option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# Tesseract language data
+*.traineddata

--- a/Config/Language.cfg
+++ b/Config/Language.cfg
@@ -1,0 +1,7 @@
+# =================================================================
+# OCR language for Tesseract
+# Supported options:
+#   eng - English (default)
+#   por - Portuguese (Brazil)
+# =================================================================
+Language | eng

--- a/EPW Recaster.csproj
+++ b/EPW Recaster.csproj
@@ -400,6 +400,9 @@
     <None Include="Config\Params.cfg">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Config\Language.cfg">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Content Include="GitHub Assets\Capture Region.png" />
     <Content Include="GitHub Assets\Combo Stats.png" />
     <Content Include="GitHub Assets\Condition Entry.png" />

--- a/MainGui.Designer.cs
+++ b/MainGui.Designer.cs
@@ -33,6 +33,7 @@ namespace EPW_Recaster
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainGui));
             this.seeThroughRegion = new System.Windows.Forms.PictureBox();
             this.metroStyleManager = new MetroFramework.Components.MetroStyleManager(this.components);
+            this.btnSwitchLanguage = new MetroFramework.Controls.MetroButton();
             this.btnAddCondition = new MetroFramework.Controls.MetroButton();
             this.numAmount = new System.Windows.Forms.NumericUpDown();
             this.lblAmount = new MetroFramework.Controls.MetroLabel();
@@ -78,10 +79,20 @@ namespace EPW_Recaster
             ((System.ComponentModel.ISupportInitialize)(this.numSubSubSubAmount)).BeginInit();
             this.cmExportImport.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
+            // btnSwitchLanguage
+            //
+            this.btnSwitchLanguage.Location = new System.Drawing.Point(23, 54);
+            this.btnSwitchLanguage.Name = "btnSwitchLanguage";
+            this.btnSwitchLanguage.Size = new System.Drawing.Size(75, 23);
+            this.btnSwitchLanguage.TabIndex = 2;
+            this.btnSwitchLanguage.Text = "ENG";
+            this.btnSwitchLanguage.UseSelectable = true;
+            this.btnSwitchLanguage.Click += new System.EventHandler(this.btnSwitchLanguage_Click);
+            //
             // seeThroughRegion
-            // 
-            this.seeThroughRegion.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            //
+            this.seeThroughRegion.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.seeThroughRegion.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(64)))), ((int)(((byte)(0)))));
@@ -602,6 +613,7 @@ namespace EPW_Recaster
             this.Controls.Add(this.btnNew);
             this.Controls.Add(this.btnRetain);
             this.Controls.Add(this.captureRegion);
+            this.Controls.Add(this.btnSwitchLanguage);
             this.Controls.Add(this.seeThroughRegion);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
@@ -637,6 +649,7 @@ namespace EPW_Recaster
 
         #endregion
         private System.Windows.Forms.PictureBox seeThroughRegion;
+        private MetroFramework.Controls.MetroButton btnSwitchLanguage;
         private MetroFramework.Controls.MetroButton btnAddCondition;
         private System.Windows.Forms.NumericUpDown numAmount;
         private System.Windows.Forms.ComboBox cbTerms;

--- a/MainGui.cs
+++ b/MainGui.cs
@@ -238,6 +238,9 @@ namespace EPW_Recaster
                 InitializeProgressHandling();
 
                 InitializeMainGuiStyle();
+
+                SetLanguageFromCfg();
+                btnSwitchLanguage.Text = Tesseract.Ocr.Language.ToUpper();
             }
             catch (Exception ex)
             {
@@ -1320,6 +1323,11 @@ namespace EPW_Recaster
         private void MainGui_Shown(object sender, EventArgs e)
         {
             CheckAdminPrivileges();
+        }
+
+        private void btnSwitchLanguage_Click(object sender, EventArgs e)
+        {
+            ToggleLanguage();
         }
 
         private void btnAddCondition_Click(object sender, EventArgs e)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ ___
 
 - Extract the contents of the provided package<br />to any folder that has write privileges.<br />( *f.e.* `Desktop` | `C:\Apps\EPW Recaster` | ... )
 - Launch `EPW Recaster(.exe)`.
+ - Click the language button on the main form to toggle between English and Portuguese OCR (or edit `Config/Language.cfg` manually). Missing Tesseract language data such as `por.traineddata` is downloaded automatically.
 
 ### ❗ Additional Setup Prerequisites ❗
 


### PR DESCRIPTION
## Summary
- download missing Tesseract language data automatically
- ignore bundled traineddata files and document download behavior

## Testing
- `apt-get update`
- `apt-get install -y mono-complete`
- `xbuild 'EPW Recaster.sln'` *(missing NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bc963cfb808324b7dcc7e1e31e5719