### PR TITLE
Enable draggable bot buttons

### DIFF
--- a/MainGui.Designer.cs
+++ b/MainGui.Designer.cs
@@ -189,33 +189,39 @@ namespace EPW_Recaster
             // 
             // btnRetain
             // 
-            this.btnRetain.Enabled = false;
             this.btnRetain.Location = new System.Drawing.Point(42, 253);
             this.btnRetain.Name = "btnRetain";
             this.btnRetain.Size = new System.Drawing.Size(10, 10);
             this.btnRetain.TabIndex = 17;
             this.btnRetain.UseSelectable = true;
-            // 
+            this.btnRetain.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseDown);
+            this.btnRetain.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseMove);
+            this.btnRetain.MouseUp += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseUp);
+            //
             // btnNew
-            // 
-            this.btnNew.Enabled = false;
+            //
             this.btnNew.Location = new System.Drawing.Point(246, 253);
             this.btnNew.Name = "btnNew";
             this.btnNew.Size = new System.Drawing.Size(10, 10);
             this.btnNew.TabIndex = 18;
             this.btnNew.UseSelectable = true;
-            // 
+            this.btnNew.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseDown);
+            this.btnNew.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseMove);
+            this.btnNew.MouseUp += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseUp);
+            //
             // btnReproduce
-            // 
-            this.btnReproduce.Enabled = false;
+            //
             this.btnReproduce.Location = new System.Drawing.Point(143, 266);
             this.btnReproduce.Name = "btnReproduce";
             this.btnReproduce.Size = new System.Drawing.Size(10, 10);
             this.btnReproduce.TabIndex = 19;
             this.btnReproduce.UseSelectable = true;
-            // 
+            this.btnReproduce.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseDown);
+            this.btnReproduce.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseMove);
+            this.btnReproduce.MouseUp += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseUp);
+            //
             // lblCaptureRegion
-            // 
+            //
             this.lblCaptureRegion.AutoSize = true;
             this.lblCaptureRegion.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(64)))), ((int)(((byte)(0)))));
             this.lblCaptureRegion.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));

--- a/MainGui.cs
+++ b/MainGui.cs
@@ -30,6 +30,9 @@ namespace EPW_Recaster
 
         private double CaptureRegionHeightClipping { get; set; } = 0.75;
 
+        private Control dragButton = null;
+        private Point dragOffset;
+
         #endregion Main Gui.
 
         #region Info Gui.
@@ -2448,6 +2451,35 @@ namespace EPW_Recaster
             btnReproduce.Location = new Point(
                 seeThroughRegion.Location.X + (int)positionReproduceX - (int)Math.Round(0.50 * btnReproduce.Width),
                 seeThroughRegion.Location.Y + (int)positionReproduceY - (int)Math.Round(0.50 * btnReproduce.Height));
+        }
+
+        private void MoveButton_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                dragButton = sender as Control;
+                dragOffset = e.Location;
+            }
+        }
+
+        private void MoveButton_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (dragButton != null)
+            {
+                int newX = dragButton.Left + e.X - dragOffset.X;
+                int newY = dragButton.Top + e.Y - dragOffset.Y;
+
+                Rectangle bounds = seeThroughRegion.Bounds;
+                newX = Math.Max(bounds.Left, Math.Min(newX, bounds.Right - dragButton.Width));
+                newY = Math.Max(bounds.Top, Math.Min(newY, bounds.Bottom - dragButton.Height));
+
+                dragButton.Location = new Point(newX, newY);
+            }
+        }
+
+        private void MoveButton_MouseUp(object sender, MouseEventArgs e)
+        {
+            dragButton = null;
         }
 
         #region Drag and drop rows reorder related.


### PR DESCRIPTION
## Summary
- Allow Retain, New, and Reproduce buttons to be dragged inside the capture region for manual positioning.
- Add shared mouse handlers and tracking fields to move buttons while constraining movement inside the capture area.

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda2e2c7808324a701b1e254a0c931