### PR TITLE
Enable draggable bot buttons

### DIFF
--- a/MainGui.Designer.cs
+++ b/MainGui.Designer.cs
@@ -189,33 +189,30 @@ namespace EPW_Recaster
             // 
             // btnRetain
             // 
-            this.btnRetain.Enabled = false;
             this.btnRetain.Location = new System.Drawing.Point(42, 253);
             this.btnRetain.Name = "btnRetain";
             this.btnRetain.Size = new System.Drawing.Size(10, 10);
             this.btnRetain.TabIndex = 17;
             this.btnRetain.UseSelectable = true;
-            // 
+            //
             // btnNew
-            // 
-            this.btnNew.Enabled = false;
+            //
             this.btnNew.Location = new System.Drawing.Point(246, 253);
             this.btnNew.Name = "btnNew";
             this.btnNew.Size = new System.Drawing.Size(10, 10);
             this.btnNew.TabIndex = 18;
             this.btnNew.UseSelectable = true;
-            // 
+            //
             // btnReproduce
-            // 
-            this.btnReproduce.Enabled = false;
+            //
             this.btnReproduce.Location = new System.Drawing.Point(143, 266);
             this.btnReproduce.Name = "btnReproduce";
             this.btnReproduce.Size = new System.Drawing.Size(10, 10);
             this.btnReproduce.TabIndex = 19;
             this.btnReproduce.UseSelectable = true;
-            // 
+            //
             // lblCaptureRegion
-            // 
+            //
             this.lblCaptureRegion.AutoSize = true;
             this.lblCaptureRegion.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(64)))), ((int)(((byte)(0)))));
             this.lblCaptureRegion.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));

--- a/MainGui.cs
+++ b/MainGui.cs
@@ -30,6 +30,9 @@ namespace EPW_Recaster
 
         private double CaptureRegionHeightClipping { get; set; } = 0.75;
 
+        private Control _draggedButton = null;
+        private Point _dragOffset;
+
         #endregion Main Gui.
 
         #region Info Gui.
@@ -241,12 +244,23 @@ namespace EPW_Recaster
 
                 SetLanguageFromCfg();
                 btnSwitchLanguage.Text = Tesseract.Ocr.Language.ToUpper();
+
+                EnableButtonDrag(btnRetain);
+                EnableButtonDrag(btnNew);
+                EnableButtonDrag(btnReproduce);
             }
             catch (Exception ex)
             {
                 MessageBox.Show("" + ex, "Exception caught");
                 this.Close();
             }
+        }
+
+        private void EnableButtonDrag(Control button)
+        {
+            button.MouseDown += MoveButton_MouseDown;
+            button.MouseMove += MoveButton_MouseMove;
+            button.MouseUp += MoveButton_MouseUp;
         }
 
         private void CheckAdminPrivileges()
@@ -2448,6 +2462,35 @@ namespace EPW_Recaster
             btnReproduce.Location = new Point(
                 seeThroughRegion.Location.X + (int)positionReproduceX - (int)Math.Round(0.50 * btnReproduce.Width),
                 seeThroughRegion.Location.Y + (int)positionReproduceY - (int)Math.Round(0.50 * btnReproduce.Height));
+        }
+
+        private void MoveButton_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                _draggedButton = sender as Control;
+                _dragOffset = e.Location;
+            }
+        }
+
+        private void MoveButton_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (_draggedButton != null)
+            {
+                int newX = _draggedButton.Left + e.X - _dragOffset.X;
+                int newY = _draggedButton.Top + e.Y - _dragOffset.Y;
+
+                Rectangle bounds = seeThroughRegion.ClientRectangle;
+                newX = Math.Max(bounds.Left, Math.Min(newX, bounds.Right - _draggedButton.Width));
+                newY = Math.Max(bounds.Top, Math.Min(newY, bounds.Bottom - _draggedButton.Height));
+
+                _draggedButton.Location = new Point(newX, newY);
+            }
+        }
+
+        private void MoveButton_MouseUp(object sender, MouseEventArgs e)
+        {
+            _draggedButton = null;
         }
 
         #region Drag and drop rows reorder related.


### PR DESCRIPTION
## Summary
- Register drag handlers for bot buttons in code instead of the designer, improving maintainability
- Track active button dragging with dedicated fields and clamp movement within the capture region

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda2e2c7808324a701b1e254a0c931