### PR TITLE
feat: make capture buttons draggable

### DIFF
--- a/MainGui.Designer.cs
+++ b/MainGui.Designer.cs
@@ -190,8 +190,7 @@ namespace EPW_Recaster
             this.captureRegion.TabStop = false;
             // 
             // btnRetain
-            // 
-            this.btnRetain.Enabled = false;
+            //
             this.btnRetain.Location = new System.Drawing.Point(42, 253);
             this.btnRetain.Name = "btnRetain";
             this.btnRetain.Size = new System.Drawing.Size(10, 10);
@@ -203,7 +202,6 @@ namespace EPW_Recaster
             //
             // btnNew
             //
-            this.btnNew.Enabled = false;
             this.btnNew.Location = new System.Drawing.Point(246, 253);
             this.btnNew.Name = "btnNew";
             this.btnNew.Size = new System.Drawing.Size(10, 10);
@@ -215,7 +213,6 @@ namespace EPW_Recaster
             //
             // btnReproduce
             //
-            this.btnReproduce.Enabled = false;
             this.btnReproduce.Location = new System.Drawing.Point(143, 266);
             this.btnReproduce.Name = "btnReproduce";
             this.btnReproduce.Size = new System.Drawing.Size(10, 10);

--- a/MainGui.Designer.cs
+++ b/MainGui.Designer.cs
@@ -197,25 +197,34 @@ namespace EPW_Recaster
             this.btnRetain.Size = new System.Drawing.Size(10, 10);
             this.btnRetain.TabIndex = 17;
             this.btnRetain.UseSelectable = true;
-            // 
+            this.btnRetain.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseDown);
+            this.btnRetain.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseMove);
+            this.btnRetain.MouseUp += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseUp);
+            //
             // btnNew
-            // 
+            //
             this.btnNew.Enabled = false;
             this.btnNew.Location = new System.Drawing.Point(246, 253);
             this.btnNew.Name = "btnNew";
             this.btnNew.Size = new System.Drawing.Size(10, 10);
             this.btnNew.TabIndex = 18;
             this.btnNew.UseSelectable = true;
-            // 
+            this.btnNew.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseDown);
+            this.btnNew.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseMove);
+            this.btnNew.MouseUp += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseUp);
+            //
             // btnReproduce
-            // 
+            //
             this.btnReproduce.Enabled = false;
             this.btnReproduce.Location = new System.Drawing.Point(143, 266);
             this.btnReproduce.Name = "btnReproduce";
             this.btnReproduce.Size = new System.Drawing.Size(10, 10);
             this.btnReproduce.TabIndex = 19;
             this.btnReproduce.UseSelectable = true;
-            // 
+            this.btnReproduce.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseDown);
+            this.btnReproduce.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseMove);
+            this.btnReproduce.MouseUp += new System.Windows.Forms.MouseEventHandler(this.MoveButton_MouseUp);
+            //
             // lblCaptureRegion
             // 
             this.lblCaptureRegion.AutoSize = true;

--- a/MainGui.cs
+++ b/MainGui.cs
@@ -31,6 +31,9 @@ namespace EPW_Recaster
 
         private double CaptureRegionHeightClipping { get; set; } = 0.75;
 
+        private Control dragButton = null;
+        private Point dragOffset;
+
         #endregion Main Gui.
 
         #region Info Gui.
@@ -2480,6 +2483,39 @@ namespace EPW_Recaster
                 seeThroughRegion.Location.X + (int)positionReproduceX - (int)Math.Round(0.50 * btnReproduce.Width),
                 seeThroughRegion.Location.Y + (int)positionReproduceY - (int)Math.Round(0.50 * btnReproduce.Height));
         }
+
+        #region Button drag handlers.
+
+        private void MoveButton_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                dragButton = sender as Control;
+                dragOffset = e.Location;
+            }
+        }
+
+        private void MoveButton_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (dragButton != null)
+            {
+                int newX = dragButton.Left + e.X - dragOffset.X;
+                int newY = dragButton.Top + e.Y - dragOffset.Y;
+
+                Rectangle bounds = seeThroughRegion.Bounds;
+                newX = Math.Max(bounds.Left, Math.Min(newX, bounds.Right - dragButton.Width));
+                newY = Math.Max(bounds.Top, Math.Min(newY, bounds.Bottom - dragButton.Height));
+
+                dragButton.Location = new Point(newX, newY);
+            }
+        }
+
+        private void MoveButton_MouseUp(object sender, MouseEventArgs e)
+        {
+            dragButton = null;
+        }
+
+        #endregion Button drag handlers.
 
         #region Drag and drop rows reorder related.
 

--- a/MainGui.cs
+++ b/MainGui.cs
@@ -31,6 +31,14 @@ namespace EPW_Recaster
 
         private double CaptureRegionHeightClipping { get; set; } = 0.75;
 
+        // Relative button positions within the capture region (center point ratios)
+        private double retainBtnXRatio = 0.21;
+        private double retainBtnYRatio = 0.879;
+        private double newBtnXRatio = 0.81;
+        private double newBtnYRatio = 0.879;
+        private double reproduceBtnXRatio = 0.52;
+        private double reproduceBtnYRatio = 0.92;
+
         private Control dragButton = null;
         private Point dragOffset;
 
@@ -2460,24 +2468,24 @@ namespace EPW_Recaster
             int currHeight = seeThroughRegion.Height;
 
             // 'Retain the old attribute'.
-            int positionRetainX = (int)Math.Round(0.21 * currWidth);
-            int positionRetainY = (int)Math.Round(0.879 * currHeight);
+            int positionRetainX = (int)Math.Round(retainBtnXRatio * currWidth);
+            int positionRetainY = (int)Math.Round(retainBtnYRatio * currHeight);
 
             btnRetain.Location = new Point(
                 seeThroughRegion.Location.X + (int)positionRetainX - (int)Math.Round(0.50 * btnRetain.Width),
                 seeThroughRegion.Location.Y + (int)positionRetainY - (int)Math.Round(0.50 * btnRetain.Height));
 
             // 'Use the new attribute'.
-            int positionNewX = (int)Math.Round(0.81 * currWidth);
-            int positionNewY = (int)Math.Round(0.879 * currHeight);
+            int positionNewX = (int)Math.Round(newBtnXRatio * currWidth);
+            int positionNewY = (int)Math.Round(newBtnYRatio * currHeight);
 
             btnNew.Location = new Point(
                 seeThroughRegion.Location.X + (int)positionNewX - (int)Math.Round(0.50 * btnNew.Width),
                 seeThroughRegion.Location.Y + (int)positionNewY - (int)Math.Round(0.50 * btnNew.Height));
 
             // 'Reproduce'.
-            int positionReproduceX = (int)Math.Round(0.52 * currWidth);
-            int positionReproduceY = (int)Math.Round(0.92 * currHeight);
+            int positionReproduceX = (int)Math.Round(reproduceBtnXRatio * currWidth);
+            int positionReproduceY = (int)Math.Round(reproduceBtnYRatio * currHeight);
 
             btnReproduce.Location = new Point(
                 seeThroughRegion.Location.X + (int)positionReproduceX - (int)Math.Round(0.50 * btnReproduce.Width),
@@ -2512,6 +2520,29 @@ namespace EPW_Recaster
 
         private void MoveButton_MouseUp(object sender, MouseEventArgs e)
         {
+            if (dragButton != null)
+            {
+                Rectangle bounds = seeThroughRegion.Bounds;
+                double percentX = (dragButton.Left - bounds.Left + dragButton.Width / 2.0) / seeThroughRegion.Width;
+                double percentY = (dragButton.Top - bounds.Top + dragButton.Height / 2.0) / seeThroughRegion.Height;
+
+                if (dragButton == btnRetain)
+                {
+                    retainBtnXRatio = percentX;
+                    retainBtnYRatio = percentY;
+                }
+                else if (dragButton == btnNew)
+                {
+                    newBtnXRatio = percentX;
+                    newBtnYRatio = percentY;
+                }
+                else if (dragButton == btnReproduce)
+                {
+                    reproduceBtnXRatio = percentX;
+                    reproduceBtnYRatio = percentY;
+                }
+            }
+
             dragButton = null;
         }
 


### PR DESCRIPTION
## Summary
- allow dragging Retain, New, and Reproduce buttons within capture region
- track dragging state to move buttons and keep them inside container

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb3a44f4c83249fa1daf6e39889f5