### PR TITLE
Include Portuguese trained data file in build output

### DIFF
--- a/EPW Recaster.csproj
+++ b/EPW Recaster.csproj
@@ -368,6 +368,9 @@
     <None Include="Tesseract\5 %28Alpha%29\tessdata\osd.traineddata">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Tesseract\5 %28Alpha%29\tessdata\por.traineddata">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Tesseract\5 %28Alpha%29\tessdata\pdf.ttf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary
- Include por.traineddata so Portuguese OCR language data is copied to the output

## Testing
- `dotnet msbuild "EPW Recaster.sln" /p:Configuration=Release` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fd96151883249d1fa8e417c81884